### PR TITLE
修复在IE 8下显示bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ $.fn.popImg = function() {
     });
   });
 
-  $(window).on("click keydown", function(evt){
+  $("body").on("click keydown", function(evt){
     if(evt.type == "keydown" && evt.keyCode === 27) {
       $layer.fadeOut(300);
       $("img[data-b-img]").remove();


### PR DESCRIPTION
在IE 8下 单击图片放大后，再次单击或按Esc键无法清楚弹出层，将click keydown事件绑定到body上后问题得到解决
